### PR TITLE
MacOS Support

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-x86_64"

--- a/src/app.rs
+++ b/src/app.rs
@@ -567,6 +567,8 @@ impl App {
         return load_proc_memory_linux(self, pid, start, size, is_write, font, msg);
         #[cfg(windows)]
         return crate::windows::load_proc_memory(self, pid, start, size, is_write, font);
+        #[cfg(target_os = "macos")]
+        return load_proc_memory_macos(self, pid, start, size, is_write, font, msg);
     }
 
     pub fn consume_meta_from_file(&mut self, path: PathBuf) -> Result<(), anyhow::Error> {
@@ -594,6 +596,34 @@ impl App {
 
 #[cfg(target_os = "linux")]
 fn load_proc_memory_linux(
+    app: &mut App,
+    pid: sysinfo::Pid,
+    start: usize,
+    size: usize,
+    is_write: bool,
+    font: &Font,
+    msg: &mut MessageDialog,
+) -> anyhow::Result<()> {
+    app.load_file_args(
+        Args {
+            src: SourceArgs {
+                file: Some(Path::new("/proc/").join(pid.to_string()).join("mem")),
+                jump: None,
+                hard_seek: Some(start),
+                take: Some(size),
+                read_only: !is_write,
+                stream: false,
+            },
+            recent: false,
+            meta: None,
+        },
+        font,
+        msg,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn load_proc_memory_macos(
     app: &mut App,
     pid: sysinfo::Pid,
     start: usize,


### PR DESCRIPTION
Hi,

I have done two changes. One is fairly innocuous and adds a toolchain requirement for nightly. The other just copies the `load_proc_mem_linux()` to allow this to compile on a mac. I have tested it on my macbook and it works.