### PR TITLE
pin nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-02-26"


### PR DESCRIPTION
This project makes use of some questionably stable nightly features. To make sure that there aren't suddenly nightly updates that break this, pin the version so that it can only be bumped once a version has been tested.